### PR TITLE
:bug: fix announcement XSS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "app",
       "version": "1.3.0",
       "dependencies": {
-        "@types/dompurify": "^3.2.0",
         "@types/uuid": "^10.0.0",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.1",
@@ -2878,16 +2877,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "app",
       "version": "1.3.0",
       "dependencies": {
+        "@types/dompurify": "^3.2.0",
         "@types/uuid": "^10.0.0",
         "clsx": "^2.1.1",
+        "dompurify": "^3.3.1",
         "jsqr": "1.4.0",
         "lucide-react": "^0.344.0",
         "prop-types": "15.8.1",
@@ -80,7 +82,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2878,6 +2879,16 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
+      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
+      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2891,7 +2902,6 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2907,7 +2917,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -2956,7 +2966,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3165,7 +3174,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3622,6 +3630,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5244,7 +5261,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5257,7 +5273,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6178,7 +6193,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -6506,7 +6520,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6903,7 +6916,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@types/dompurify": "^3.2.0",
     "@types/uuid": "^10.0.0",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@types/dompurify": "^3.2.0",
     "@types/uuid": "^10.0.0",
     "clsx": "^2.1.1",
+    "dompurify": "^3.3.1",
     "jsqr": "1.4.0",
     "lucide-react": "^0.344.0",
     "prop-types": "15.8.1",

--- a/src/components/AnnouncementModal.tsx
+++ b/src/components/AnnouncementModal.tsx
@@ -81,12 +81,22 @@ const AnnouncementModal: React.FC = () => {
         const sanitized = sanitizeAnnouncementHtml(text).trim();
         if (!sanitized) return;
 
-        const hash = await hashContent(sanitized);
-        if (hash !== localStorage.getItem(STORAGE_KEY)) {
-          localStorage.setItem(STORAGE_KEY, hash);
-          setContent(sanitized);
-          setVisible(true);
+        const currentHash = await hashContent(sanitized);
+        const storedHash = localStorage.getItem(STORAGE_KEY);
+
+        // Backward compatibility: older versions stored hash of raw content.
+        if (storedHash === currentHash) return;
+        if (storedHash) {
+          const legacyHash = await hashContent(text);
+          if (storedHash === legacyHash) {
+            localStorage.setItem(STORAGE_KEY, currentHash);
+            return;
+          }
         }
+
+        localStorage.setItem(STORAGE_KEY, currentHash);
+        setContent(sanitized);
+        setVisible(true);
       } catch {
         // 公告是非关键功能，静默失败
       }

--- a/src/components/AnnouncementModal.tsx
+++ b/src/components/AnnouncementModal.tsx
@@ -1,8 +1,32 @@
 import React, { useEffect, useState } from 'react';
 import { X, Megaphone } from 'lucide-react';
+import DOMPurify from 'dompurify';
 
 const ANNOUNCEMENT_URL = 'https://www.transmtf.com/api/announcement/tmtf_b243d43f97b51b4fef747016';
 const STORAGE_KEY = 'tmtf_announcement_hash';
+const ANNOUNCEMENT_ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'b', 'i', 'u',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'span', 'div',
+  'a', 'blockquote', 'code', 'pre', 'hr', 'img'
+];
+const ANNOUNCEMENT_ALLOWED_ATTR = [
+  'href', 'title', 'target', 'rel', 'src', 'alt',
+  'colspan', 'rowspan', 'scope'
+];
+
+function sanitizeAnnouncementHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ANNOUNCEMENT_ALLOWED_TAGS,
+    ALLOWED_ATTR: ANNOUNCEMENT_ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: false,
+    FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed', 'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'],
+    FORBID_ATTR: ['style'],
+    ALLOWED_URI_REGEXP: /^(?:(?:https?):|mailto:|tel:|\/)/i,
+  });
+}
 
 async function hashContent(content: string): Promise<string> {
   const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(content));
@@ -23,10 +47,13 @@ const AnnouncementModal: React.FC = () => {
         const text = (await res.text()).trim();
         if (!text) return;
 
-        const hash = await hashContent(text);
+        const sanitized = sanitizeAnnouncementHtml(text).trim();
+        if (!sanitized) return;
+
+        const hash = await hashContent(sanitized);
         if (hash !== localStorage.getItem(STORAGE_KEY)) {
           localStorage.setItem(STORAGE_KEY, hash);
-          setContent(text);
+          setContent(sanitized);
           setVisible(true);
         }
       } catch {

--- a/src/components/AnnouncementModal.tsx
+++ b/src/components/AnnouncementModal.tsx
@@ -32,9 +32,10 @@ function enforceSafeLinkTargets(html: string): string {
 
   template.content.querySelectorAll('a[target]').forEach((anchor) => {
     const target = anchor.getAttribute('target');
-    if (!target) return;
+    if (target == null) return;
 
-    if (target.toLowerCase() !== '_blank') {
+    const normalizedTarget = target.trim().toLowerCase();
+    if (normalizedTarget !== '_blank') {
       anchor.removeAttribute('target');
       return;
     }

--- a/src/components/AnnouncementModal.tsx
+++ b/src/components/AnnouncementModal.tsx
@@ -16,16 +16,46 @@ const ANNOUNCEMENT_ALLOWED_ATTR = [
   'href', 'title', 'target', 'rel', 'src', 'alt',
   'colspan', 'rowspan', 'scope'
 ];
+const ANNOUNCEMENT_SAFE_REL_TOKENS = ['noopener', 'noreferrer'] as const;
+const ANNOUNCEMENT_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: ANNOUNCEMENT_ALLOWED_TAGS,
+  ALLOWED_ATTR: ANNOUNCEMENT_ALLOWED_ATTR,
+  ALLOW_DATA_ATTR: false,
+  FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed', 'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'],
+  FORBID_ATTR: ['style'],
+  ALLOWED_URI_REGEXP: /^(?:(?:https?):|mailto:|tel:|\/)/i,
+};
+
+function enforceSafeLinkTargets(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+
+  template.content.querySelectorAll('a[target]').forEach((anchor) => {
+    const target = anchor.getAttribute('target');
+    if (!target) return;
+
+    if (target.toLowerCase() !== '_blank') {
+      anchor.removeAttribute('target');
+      return;
+    }
+
+    anchor.setAttribute('target', '_blank');
+    const relTokens = new Set(
+      (anchor.getAttribute('rel') ?? '')
+        .split(/\s+/)
+        .map(token => token.trim().toLowerCase())
+        .filter(Boolean)
+    );
+    ANNOUNCEMENT_SAFE_REL_TOKENS.forEach(token => relTokens.add(token));
+    anchor.setAttribute('rel', Array.from(relTokens).join(' '));
+  });
+
+  return template.innerHTML;
+}
 
 function sanitizeAnnouncementHtml(html: string): string {
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ANNOUNCEMENT_ALLOWED_TAGS,
-    ALLOWED_ATTR: ANNOUNCEMENT_ALLOWED_ATTR,
-    ALLOW_DATA_ATTR: false,
-    FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed', 'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'],
-    FORBID_ATTR: ['style'],
-    ALLOWED_URI_REGEXP: /^(?:(?:https?):|mailto:|tel:|\/)/i,
-  });
+  const sanitized = DOMPurify.sanitize(html, ANNOUNCEMENT_SANITIZE_CONFIG);
+  return enforceSafeLinkTargets(sanitized);
 }
 
 async function hashContent(content: string): Promise<string> {

--- a/src/components/AnnouncementModal.tsx
+++ b/src/components/AnnouncementModal.tsx
@@ -23,7 +23,7 @@ const ANNOUNCEMENT_SANITIZE_CONFIG = {
   ALLOW_DATA_ATTR: false,
   FORBID_TAGS: ['style', 'script', 'iframe', 'object', 'embed', 'form', 'input', 'button', 'textarea', 'select', 'svg', 'math'],
   FORBID_ATTR: ['style'],
-  ALLOWED_URI_REGEXP: /^(?:(?:https?):|mailto:|tel:|\/)/i,
+  ALLOWED_URI_REGEXP: /^(?:https:|mailto:|tel:|\/(?!\/))/i,
 };
 
 function enforceSafeLinkTargets(html: string): string {


### PR DESCRIPTION
## Summary
- 引入 `DOMPurify` 对公告 HTML 做白名单净化，修复 `dangerouslySetInnerHTML` 场景下的 XSS 风险
- 仅允许安全标签/属性，禁止 `script/iframe/style/svg/math` 等高风险标签与 `style` 属性
- 对链接做二次安全收敛：
  - 非 `_blank` 的 `target` 会被移除
  - `_blank` 链接会强制带上 `rel="noopener noreferrer"`
- URI 规则收紧为仅允许 `https`、`mailto`、`tel`、以及站内相对路径（并拒绝 `//` 协议相对 URL）
- 对历史用户做兼容迁移：若本地存的是“旧版原文哈希”，会静默迁移到“新版净化后哈希”，避免一次性重弹

## Review Feedback Addressed
- [x] 移除冗余类型依赖 `@types/dompurify`
- [x] 修复 reverse tabnabbing 风险
- [x] 处理“哈希策略切换导致旧用户重弹”的兼容问题
- [x] 收紧 URI 方案，避免 `http://` 与协议相对 URL 偏离安全意图

## Test Plan
- [x] `npm run build` 通过
- [x] 公告内容净化逻辑确定性用例（6 组）
- [x] 随机 fuzz 压测（12,000 轮）
- [x] 边界回归：修复 `target=""` 残留问题后复测通过
