### PR TITLE
Prevent logout/local-clear race: revoke token and block cloud sync during logout

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -318,9 +318,10 @@ class ApiClient {
     });
   }
 
-  async logout(): Promise<ApiResponse<LogoutResponse>> {
+  async logout(tokenOverride?: string): Promise<ApiResponse<LogoutResponse>> {
     return this.request<LogoutResponse>('/auth/logout', {
       method: 'POST',
+      headers: tokenOverride ? { Authorization: `Bearer ${tokenOverride}` } : undefined,
     });
   }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import apiClient from '../api/client';
 import type { AuthTokens } from '../api/types';
 import { clearSecurityPassword } from '../utils/crypto';
 import { deleteCookie, getCookie, setCookie } from '../utils/cookies';
+import { setLogoutInProgress } from '../utils/authSessionState';
 
 interface User {
   username: string;
@@ -13,6 +14,7 @@ interface AuthContextType {
   accessToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isLoggingOut: boolean;
   login: (username: string, password: string, turnstileToken?: string) => Promise<{ success: boolean; error?: string; status?: number }>;
   register: (username: string, password: string, turnstileToken?: string) => Promise<{ success: boolean; error?: string }>;
   loginWithTokens: (tokens: AuthTokens, username: string) => void;
@@ -49,42 +51,59 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<User | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const refreshPromiseRef = React.useRef<Promise<boolean> | null>(null);
 
   const logout = useCallback(async (clearLocalData: boolean = false) => {
-    try {
-      await apiClient.logout();
-    } catch (error) {
-      console.error('Failed to logout from server:', error);
+    if (isLoggingOut) {
+      return;
     }
+
+    const tokenToRevoke = accessToken || getStoredValue(TOKEN_STORAGE_KEY);
+
+    setIsLoggingOut(true);
+    setLogoutInProgress(true);
 
     setAccessToken(null);
     setUser(null);
     apiClient.setAccessToken(null);
 
-    // Always clear auth tokens
+    // Always clear auth tokens before touching local data so sync can no longer authenticate.
     clearStoredValue(TOKEN_STORAGE_KEY);
     clearStoredValue(REFRESH_TOKEN_STORAGE_KEY);
     clearStoredValue(USERNAME_STORAGE_KEY);
 
-    // Always clear security password cookie
     try {
-      await clearSecurityPassword();
-    } catch (error) {
-      console.error('Failed to clear security password during logout:', error);
-    }
+      try {
+        if (tokenToRevoke) {
+          await apiClient.logout(tokenToRevoke);
+        }
+      } catch (error) {
+        console.error('Failed to logout from server:', error);
+      }
 
-    // Optionally clear local user data
-    if (clearLocalData) {
-      localStorage.removeItem('hrt-events');
-      localStorage.removeItem('hrt-weight');
-      localStorage.removeItem('hrt-lab-results');
-      localStorage.removeItem('hrt-lang');
-      localStorage.removeItem('hrt-last-modified');
-      localStorage.removeItem('hrt-last-sync-time');
-      localStorage.removeItem('hrt-last-pull-time');
+      // Always clear security password cookie
+      try {
+        await clearSecurityPassword();
+      } catch (error) {
+        console.error('Failed to clear security password during logout:', error);
+      }
+
+      // Optionally clear local user data
+      if (clearLocalData) {
+        localStorage.removeItem('hrt-events');
+        localStorage.removeItem('hrt-weight');
+        localStorage.removeItem('hrt-lab-results');
+        localStorage.removeItem('hrt-lang');
+        localStorage.removeItem('hrt-last-modified');
+        localStorage.removeItem('hrt-last-sync-time');
+        localStorage.removeItem('hrt-last-pull-time');
+      }
+    } finally {
+      setLogoutInProgress(false);
+      setIsLoggingOut(false);
     }
-  }, []);
+  }, [accessToken, isLoggingOut]);
 
   const refreshAccessToken = useCallback(async (): Promise<boolean> => {
     // Prevent multiple simultaneous refresh attempts
@@ -223,6 +242,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         accessToken,
         isAuthenticated: !!user && !!accessToken,
         isLoading,
+        isLoggingOut,
         login,
         register,
         loginWithTokens,

--- a/src/contexts/CloudSyncContext.tsx
+++ b/src/contexts/CloudSyncContext.tsx
@@ -3,6 +3,7 @@ import apiClient from '../api/client';
 import { useAuth } from './AuthContext';
 import { useSecurityPassword } from './SecurityPasswordContext';
 import { computeDataHash } from '../utils/dataHash';
+import { isLogoutInProgress } from '../utils/authSessionState';
 
 interface CloudSyncContextType {
   isSyncing: boolean;
@@ -129,7 +130,7 @@ export const CloudSyncProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const syncToCloud = useCallback(async () => {
     // CRITICAL FIX: Password checks BEFORE ref check (unconditional guard)
     // Don't sync if not authenticated
-    if (!isAuthenticated) {
+    if (!isAuthenticated || isLogoutInProgress()) {
       return;
     }
 
@@ -182,7 +183,7 @@ export const CloudSyncProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const syncFromCloud = useCallback(async () => {
     // CRITICAL FIX: Password checks BEFORE ref check (unconditional guard)
     // Don't sync if not authenticated
-    if (!isAuthenticated) {
+    if (!isAuthenticated || isLogoutInProgress()) {
       return;
     }
 
@@ -329,7 +330,7 @@ export const CloudSyncProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   // Smart initial sync: compare local and cloud data, sync the newer one
   const initialSmartSync = useCallback(async () => {
     // Same guards as other sync functions
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || isLogoutInProgress()) return;
     if (hasSecurityPassword && !isVerified) return;
     if (hasSecurityPassword && passwordVerificationFailed) return;
     if (hasSecurityPassword && !securityPassword) return;
@@ -394,7 +395,7 @@ export const CloudSyncProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // Watch for localStorage changes and auto-sync
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || isLogoutInProgress()) return;
 
     const triggerSync = () => {
       syncToCloud();
@@ -426,7 +427,7 @@ export const CloudSyncProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // Poll cloud every 3 seconds
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || isLogoutInProgress()) return;
 
     if (shouldPullFromCloud()) {
       // Initial smart sync when user logs in (only if we should pull)

--- a/src/utils/authSessionState.ts
+++ b/src/utils/authSessionState.ts
@@ -1,0 +1,7 @@
+let logoutInProgress = false;
+
+export const setLogoutInProgress = (value: boolean) => {
+  logoutInProgress = value;
+};
+
+export const isLogoutInProgress = () => logoutInProgress;


### PR DESCRIPTION
### Motivation
- Prevent a race where a user choosing “clear local data” during manual logout could have deletions pushed to the cloud because background sync still had a valid token or ran concurrently.
- Ensure the server-side session/token is revoked while avoiding any window where the client can still authenticate sync requests.

### Description
- Add a small shared flag module `src/utils/authSessionState.ts` with `setLogoutInProgress` and `isLogoutInProgress` to mark logout state.
- Update `AuthContext.logout` to capture the current token, immediately clear client auth state and cookies, set the logout-in-progress guard, then call `apiClient.logout` with the captured token, and finally perform security-cookie cleanup and optional local-data removal inside a `finally` block that always clears the guard.
- Change `ApiClient.logout` to accept an optional `tokenOverride` and, when provided, include an `Authorization: Bearer <token>` header so the client can revoke the server session after local state is cleared.
- Harden `CloudSyncContext` (push/pull/initial sync, storage listener and polling) to short-circuit whenever `isLogoutInProgress()` is true to avoid syncing while logout/local-clear is in progress.

### Testing
- Ran `npm run build` which completed successfully and produced a production bundle.
- Ran `npm exec -- tsc --noEmit` which failed, but the failures are from existing unrelated TypeScript issues in the repository (e.g. missing `import.meta.env` typings) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc26696730832c83e0b942fb094072)