### PR TITLE
调整曲线图主题网格线样式

### DIFF
--- a/src/components/ResultChart.tsx
+++ b/src/components/ResultChart.tsx
@@ -801,7 +801,7 @@ const ResultChart = ({ sim, events, labResults = [], simCI, baselineE2PGmL, nowH
                                 <stop offset="95%" stopColor="#f43f5e" stopOpacity={0}/>
                             </linearGradient>
                         </defs>
-                        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border-secondary)" />
+                        <CartesianGrid strokeDasharray="4 4" vertical={false} stroke="var(--text-tertiary)" strokeOpacity={0.65} />
                         <XAxis
                             dataKey="time"
                             type="number"

--- a/src/components/ResultChartStatic.tsx
+++ b/src/components/ResultChartStatic.tsx
@@ -235,7 +235,7 @@ const ResultChartStatic: React.FC<Props> = ({ sim, events, labResults, simCI, ba
     // Theme-aware colors
     const accent500 = themeColors?.[500] ?? '#f43f5e';
     const accent300 = themeColors?.[300] ?? '#fda4af';
-    const gridColor = isDark ? '#1e293b' : '#e2e8f0';
+    const gridColor = isDark ? '#64748b' : '#94a3b8';
     const tickColorX = isDark ? '#64748b' : '#94a3b8';
     const tickColorE2 = accent500;
     const nowLineColor = isDark ? `${accent500}80` : accent300;
@@ -254,7 +254,7 @@ const ResultChartStatic: React.FC<Props> = ({ sim, events, labResults, simCI, ba
                     <stop offset="95%" stopColor={accent500} stopOpacity={0} />
                 </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={gridColor} />
+            <CartesianGrid strokeDasharray="4 4" vertical={false} stroke={gridColor} strokeOpacity={0.65} />
             <XAxis
                 dataKey="time"
                 type="number"


### PR DESCRIPTION
原有水平网格线在明暗主题下对比度偏低，实际使用时不易辨识。本次调整增强其可见度，并保持图表主体曲线的视觉优先级。

## 修改内容

- 提高曲线图水平网格线的可见度，透明度调整为 0.65。
- 网格虚线间距由 `3 3` 调整为 `4 4`。
- 保持现有图表数据、坐标轴和曲线计算逻辑不变。

## 实现说明

- `src/components/ResultChart.tsx`：交互图改用主题文本次级颜色绘制网格线，使其自动适配明暗主题。
- `src/components/ResultChartStatic.tsx`：静态分享图分别配置明暗主题网格颜色，并与交互图使用相同透明度和虚线间距。
## 修改预览
<img width="704" height="434" alt="image" src="https://github.com/user-attachments/assets/f8bbc75d-e1c4-45f7-88d6-6e04f72180af" />
